### PR TITLE
Add README for Example 1 with source URLs and explanation of changes

### DIFF
--- a/mvnc-vs-gaoss/example1/README.md
+++ b/mvnc-vs-gaoss/example1/README.md
@@ -1,0 +1,36 @@
+# Example bytecode-level difference between Maven Central and Google Assured Open Source Software
+
+## Overview
+
+This folder shows diffs between the disassembly, produced using `javap -c -p`, of 2 copies of the class `com.google.common.jimfs.Handler` from `com.google.jimfs:jimfs:1.2`, one taken from Maven Central (mvnc) and the other from Google Assured Open Source Software (gaoss).
+The two subdirectories contain the original jars from each provider and relevant files extracted from them, for convenience.
+
+- File path within both binary jars: `com/google/common/jimfs/Handler.class`
+- Maven Central binary jar URL: https://repo1.maven.org/maven2/com/google/jimfs/jimfs/1.2/jimfs-1.2.jar
+- Maven Central source jar URL: https://repo1.maven.org/maven2/com/google/jimfs/jimfs/1.2/jimfs-1.2-sources.jar
+- Google AOSS binary jar path: `com/google/jimfs/jimfs/1.2/jimfs-1.2.jar`
+- Google AOSS source jar path: `com/google/jimfs/jimfs/1.2/jimfs-1.2-sources.jar`
+- `*.md5` files are at the same paths with `.md5` appended
+- `MANIFEST.MF` files are extracted from the respective binary jars
+
+## Summary of differences
+
+The `Handler.java` source files are identical. Both `MANIFEST.MF` files have `Build-Jdk-Spec: 11`, indicating compilers from the same JDK release. Both `Handler.class` files have major version 51, minor version 0 (JDK 7).
+
+The main difference is how line 68 of `Handler.java` is compiled:
+
+```
+      packages += "|" + parentPackage;
+```
+
+While the GAOSS bytecode creates a `StringBuilder` using its default constructor and appends the 3 components to it, the Maven Central version first calls `String.length()` twice, computing the length of the final string in order to call the 1-argument version of the `StringBuilder` constructor. The Maven Central version also redundantly calls `String.valueOf()` 3 times (on values already statically known to be `String`s).
+
+There is also some constant pool reordering affecting the bytecode in the last 3 methods (constructor, `openConnection()`, `getHostAddress()`).
+
+## Obtaining Google AOSS files
+
+After first [setting up Google Assured Open Source Software access](https://cloud.google.com/assured-open-source-software/docs/enable) for a [Google Cloud Platform](https://cloud.google.com/) account, and ensuring a valid service account access token is in the file `service-account-access-token`, GAOSS files can be downloaded using the following command, replacing `$P` with the path in question:
+
+```
+gcloud artifacts files download --location=us --project=cloud-aoss --repository=cloud-aoss-java $P --access-token-file=service-account-access-token
+```

--- a/mvnc-vs-gaoss/example1/README.md
+++ b/mvnc-vs-gaoss/example1/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This folder shows diffs between the disassembly, produced using `javap -c -p`, of 2 copies of the class `com.google.common.jimfs.Handler` from `com.google.jimfs:jimfs:1.2`, one taken from Maven Central (mvnc) and the other from Google Assured Open Source Software (gaoss).
+This folder shows the diff between the disassemblies, produced using `javap -c -p`, of 2 copies of the class `com.google.common.jimfs.Handler` from the Maven project `com.google.jimfs:jimfs:1.2`, one taken from Maven Central (mvnc) and the other from Google Assured Open Source Software (gaoss).
 The two subdirectories contain the original jars from each provider and relevant files extracted from them, for convenience.
 
 - File path within both binary jars: `com/google/common/jimfs/Handler.class`
@@ -15,7 +15,7 @@ The two subdirectories contain the original jars from each provider and relevant
 
 ## Summary of differences
 
-The `Handler.java` source files are identical. Both `MANIFEST.MF` files have `Build-Jdk-Spec: 11`, indicating compilers from the same JDK release. Both `Handler.class` files have major version 51, minor version 0 (JDK 7).
+The `Handler.java` source files are identical. Both `MANIFEST.MF` files have `Build-Jdk-Spec: 11`, indicating compilers from the same JDK release, and differ only in their `Bnd-LastModified` timestamps. Both `Handler.class` files have major version 51, minor version 0 (JDK 7).
 
 The main difference is how line 68 of `Handler.java` is compiled:
 
@@ -25,7 +25,7 @@ The main difference is how line 68 of `Handler.java` is compiled:
 
 While the GAOSS bytecode creates a `StringBuilder` using its default constructor and appends the 3 components to it, the Maven Central version first calls `String.length()` twice, computing the length of the final string in order to call the 1-argument version of the `StringBuilder` constructor. The Maven Central version also redundantly calls `String.valueOf()` 3 times (on values already statically known to be `String`s).
 
-There is also some constant pool reordering affecting the bytecode in the last 3 methods (constructor, `openConnection()`, `getHostAddress()`).
+There is also some constant pool reordering affecting indices used in the bytecode in the last 3 methods (constructor, `openConnection()`, `getHostAddress()`).
 
 ## Obtaining Google AOSS files
 


### PR DESCRIPTION
I've analysed the bytecode differences in `Handler.class`: Basically, gaoss creates a `StringBuilder` to do string concatenation using its default constructor, while mvnc first calculates the length of the final string and calls `StringBuilder`'s 1-arg constructor.