### PR TITLE
Add jnorm and jnorm2 diffs for mvnc-vs-obfs example 2

### DIFF
--- a/mvnc-vs-gaoss/example1/README.md
+++ b/mvnc-vs-gaoss/example1/README.md
@@ -3,6 +3,7 @@
 ## Overview
 
 This folder shows the diff between the disassemblies, produced using `javap -c -p`, of 2 copies of the class `com.google.common.jimfs.Handler` from the Maven project `com.google.jimfs:jimfs:1.2`, one taken from Maven Central (mvnc) and the other from Google Assured Open Source Software (gaoss).
+Each `.diff` file is produced using a command of the form `diff gaoss/X mvnc/X > X.diff`.
 The two subdirectories contain the original jars from each provider and relevant files extracted from them, for convenience.
 
 - File path within both binary jars: `com/google/common/jimfs/Handler.class`

--- a/mvnc-vs-obfs/example2/AccessEventPreSerializationTransformer.jnorm.jimple.diff
+++ b/mvnc-vs-obfs/example2/AccessEventPreSerializationTransformer.jnorm.jimple.diff
@@ -1,0 +1,4 @@
+47c47
+<         $r4 = interfaceinvoke r0.<ch.qos.logback.access.spi.IAccessEvent: java.lang.Class getClass()>();
+---
+>         $r4 = virtualinvoke r0.<java.lang.Object: java.lang.Class getClass()>();

--- a/mvnc-vs-obfs/example2/AccessEventPreSerializationTransformer.jnorm2.jimple.diff
+++ b/mvnc-vs-obfs/example2/AccessEventPreSerializationTransformer.jnorm2.jimple.diff
@@ -1,0 +1,4 @@
+25c25
+< v4 = interfaceinvoke v1.<ch.qos.logback.access.spi.IAccessEvent: java.lang.Class getClass()>();
+---
+> v4 = virtualinvoke v1.<java.lang.Object: java.lang.Class getClass()>();

--- a/mvnc-vs-obfs/example2/README.md
+++ b/mvnc-vs-obfs/example2/README.md
@@ -2,7 +2,13 @@
 
 ## Overview
 
-This folder shows the diff between the disassemblies, produced using `javap -c -p`, of 2 copies of the class `ch.qos.logback.access.net.AccessEventPreSerializationTransformer` from the Maven project `ch.qos.logback:logback-access:1.3.11`, one taken from Maven Central (mvnc) and the other from Oracle Build-From-Source (obfs).
+This folder shows differences at several equivalence levels between 2 copies of the class `ch.qos.logback.access.net.AccessEventPreSerializationTransformer` from the Maven project `ch.qos.logback:logback-access:1.3.11`, one taken from Maven Central (mvnc) and the other from Oracle Build-From-Source (obfs).
+In particular, it shows that **the main difference is not normalised away by JNorm, even with maximum normalisation turned on.**
+
+- `AccessEventPreSerializationTransformer.javap.diff`: disassemblies (produced using `javap -c -p`, `disassembly` in the paper)
+- `AccessEventPreSerializationTransformer.jnorm.jimple.diff`: Jimple (bytecode normalised using JNorm with default settings, `jnorm` in the paper)
+- `AccessEventPreSerializationTransformer.jnorm2.jimple.diff`: Jimple (bytecode normalised aggressively using JNorm with `-o -n -s -a -p` flags, `jnorm2` in the paper)
+
 The two subdirectories contain the original jars from each provider and relevant files extracted from them, for convenience.
 
 - File path within both binary jars: `ch/qos/logback/access/net/AccessEventPreSerializationTransformer.class`
@@ -27,5 +33,3 @@ The OBFS bytecode calls `getClass()` using an `invokevirtual` instruction, while
 This difference results from [a change made to `javac` in JDK18](https://github.com/openjdk/jdk/pull/5165) to reflect the fact that interfaces do not inherit from `java.lang.Object`, but instead have "mirrors" of the public methods of `java.lang.Object` ([JLS 9.2](https://docs.oracle.com/javase/specs/jls/se18/html/jls-9.html#jls-9.2)). Since `IAccessEvent` is an interface, calling `event.getClass()` is technically calling the mirror method on the interface, not the method on `java.lang.Object`.
 
 There is also some constant pool reordering affecting indices used in the remaining bytecode.
-
-**Note: This difference is not normalised away by JNorm**, either at the default settings (`jnorm` in the paper) or with maximum normalisation turned on (using `-o -n -s -a -p` flags, `jnorm2` in the paper).

--- a/mvnc-vs-obfs/example2/README.md
+++ b/mvnc-vs-obfs/example2/README.md
@@ -5,6 +5,7 @@
 This folder shows differences at several equivalence levels between 2 copies of the class `ch.qos.logback.access.net.AccessEventPreSerializationTransformer` from the Maven project `ch.qos.logback:logback-access:1.3.11`, one taken from Maven Central (mvnc) and the other from Oracle Build-From-Source (obfs).
 In particular, it shows that **the main difference is not normalised away by JNorm, even with maximum normalisation turned on.**
 
+Each `.diff` file is produced using a command of the form `diff mvnc/X obfs/X > X.diff`:
 - `AccessEventPreSerializationTransformer.javap.diff`: disassemblies (produced using `javap -c -p`, `disassembly` in the paper)
 - `AccessEventPreSerializationTransformer.jnorm.jimple.diff`: Jimple (bytecode normalised using JNorm with default settings, `jnorm` in the paper)
 - `AccessEventPreSerializationTransformer.jnorm2.jimple.diff`: Jimple (bytecode normalised aggressively using JNorm with `-o -n -s -a -p` flags, `jnorm2` in the paper)

--- a/mvnc-vs-obfs/example2/mvnc/AccessEventPreSerializationTransformer.jnorm.jimple
+++ b/mvnc-vs-obfs/example2/mvnc/AccessEventPreSerializationTransformer.jnorm.jimple
@@ -1,0 +1,77 @@
+public class ch.qos.logback.access.net.AccessEventPreSerializationTransformer extends java.lang.Object implements ch.qos.logback.core.spi.PreSerializationTransformer
+{
+
+    public void <init>()
+    {
+        ch.qos.logback.access.net.AccessEventPreSerializationTransformer r0;
+
+        r0 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+
+        specialinvoke r0.<java.lang.Object: void <init>()>();
+
+        return;
+    }
+
+    public java.io.Serializable transform(ch.qos.logback.access.spi.IAccessEvent)
+    {
+        ch.qos.logback.access.net.AccessEventPreSerializationTransformer r9;
+        java.lang.IllegalArgumentException $r1;
+        ch.qos.logback.access.spi.IAccessEvent r0;
+        java.lang.StringBuilder $r2, $r3, $r6;
+        java.lang.Class $r4;
+        java.lang.String $r5, $r7;
+        ch.qos.logback.access.spi.AccessEvent $r8;
+        boolean $z0;
+
+        r9 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+
+        r0 := @parameter0: ch.qos.logback.access.spi.IAccessEvent;
+
+        $z0 = r0 instanceof ch.qos.logback.access.spi.AccessEvent;
+
+        if $z0 == 0 goto label1;
+
+        $r8 = (ch.qos.logback.access.spi.AccessEvent) r0;
+
+        return $r8;
+
+     label1:
+        $r1 = new java.lang.IllegalArgumentException;
+
+        $r2 = new java.lang.StringBuilder;
+
+        specialinvoke $r2.<java.lang.StringBuilder: void <init>()>();
+
+        $r3 = virtualinvoke $r2.<java.lang.StringBuilder: java.lang.StringBuilder append(java.lang.String)>("Unsupported type ");
+
+        $r4 = interfaceinvoke r0.<ch.qos.logback.access.spi.IAccessEvent: java.lang.Class getClass()>();
+
+        $r5 = virtualinvoke $r4.<java.lang.Class: java.lang.String getName()>();
+
+        $r6 = virtualinvoke $r3.<java.lang.StringBuilder: java.lang.StringBuilder append(java.lang.String)>($r5);
+
+        $r7 = virtualinvoke $r6.<java.lang.StringBuilder: java.lang.String toString()>();
+
+        specialinvoke $r1.<java.lang.IllegalArgumentException: void <init>(java.lang.String)>($r7);
+
+        throw $r1;
+    }
+
+    public volatile java.io.Serializable transform(java.lang.Object)
+    {
+        ch.qos.logback.access.net.AccessEventPreSerializationTransformer r0;
+        java.lang.Object r1;
+        ch.qos.logback.access.spi.IAccessEvent $r2;
+        java.io.Serializable $r3;
+
+        r0 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+
+        r1 := @parameter0: java.lang.Object;
+
+        $r2 = (ch.qos.logback.access.spi.IAccessEvent) r1;
+
+        $r3 = virtualinvoke r0.<ch.qos.logback.access.net.AccessEventPreSerializationTransformer: java.io.Serializable transform(ch.qos.logback.access.spi.IAccessEvent)>($r2);
+
+        return $r3;
+    }
+}

--- a/mvnc-vs-obfs/example2/mvnc/AccessEventPreSerializationTransformer.jnorm2.jimple
+++ b/mvnc-vs-obfs/example2/mvnc/AccessEventPreSerializationTransformer.jnorm2.jimple
@@ -1,0 +1,31 @@
+public class ch.qos.logback.access.net.AccessEventPreSerializationTransformer extends java.lang.Object implements ch.qos.logback.core.spi.PreSerializationTransformer
+{
+public void <init>()
+{
+ch.qos.logback.access.net.AccessEventPreSerializationTransformer v0;
+v0 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+specialinvoke v0.<java.lang.Object: void <init>()>();
+return;
+}
+public java.io.Serializable transform(ch.qos.logback.access.spi.IAccessEvent)
+{
+ch.qos.logback.access.net.AccessEventPreSerializationTransformer v0;
+java.lang.Class v4;
+java.lang.String v5, v6;
+java.lang.IllegalArgumentException v3;
+ch.qos.logback.access.spi.IAccessEvent v1;
+boolean v2;
+v0 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+v1 := @parameter0: ch.qos.logback.access.spi.IAccessEvent;
+v2 = v1 instanceof ch.qos.logback.access.spi.AccessEvent;
+if v2 == 0 goto label1;
+return v1;
+label1:
+v3 = new java.lang.IllegalArgumentException;
+v4 = interfaceinvoke v1.<ch.qos.logback.access.spi.IAccessEvent: java.lang.Class getClass()>();
+v5 = virtualinvoke v4.<java.lang.Class: java.lang.String getName()>();
+v6 = dynamicinvoke "makeConcatWithConstants" <java.lang.String (java.lang.String)>(v5) <java.lang.invoke.StringConcatFactory: java.lang.invoke.CallSite makeConcatWithConstants(java.lang.invoke.MethodHandles$Lookup,java.lang.String,java.lang.invoke.MethodType,java.lang.String,java.lang.Object[])>("Unsupported type \u0001");
+specialinvoke v3.<java.lang.IllegalArgumentException: void <init>(java.lang.String)>(v6);
+throw v3;
+}
+}

--- a/mvnc-vs-obfs/example2/obfs/AccessEventPreSerializationTransformer.jnorm.jimple
+++ b/mvnc-vs-obfs/example2/obfs/AccessEventPreSerializationTransformer.jnorm.jimple
@@ -1,0 +1,77 @@
+public class ch.qos.logback.access.net.AccessEventPreSerializationTransformer extends java.lang.Object implements ch.qos.logback.core.spi.PreSerializationTransformer
+{
+
+    public void <init>()
+    {
+        ch.qos.logback.access.net.AccessEventPreSerializationTransformer r0;
+
+        r0 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+
+        specialinvoke r0.<java.lang.Object: void <init>()>();
+
+        return;
+    }
+
+    public java.io.Serializable transform(ch.qos.logback.access.spi.IAccessEvent)
+    {
+        ch.qos.logback.access.net.AccessEventPreSerializationTransformer r9;
+        java.lang.IllegalArgumentException $r1;
+        ch.qos.logback.access.spi.IAccessEvent r0;
+        java.lang.StringBuilder $r2, $r3, $r6;
+        java.lang.Class $r4;
+        java.lang.String $r5, $r7;
+        ch.qos.logback.access.spi.AccessEvent $r8;
+        boolean $z0;
+
+        r9 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+
+        r0 := @parameter0: ch.qos.logback.access.spi.IAccessEvent;
+
+        $z0 = r0 instanceof ch.qos.logback.access.spi.AccessEvent;
+
+        if $z0 == 0 goto label1;
+
+        $r8 = (ch.qos.logback.access.spi.AccessEvent) r0;
+
+        return $r8;
+
+     label1:
+        $r1 = new java.lang.IllegalArgumentException;
+
+        $r2 = new java.lang.StringBuilder;
+
+        specialinvoke $r2.<java.lang.StringBuilder: void <init>()>();
+
+        $r3 = virtualinvoke $r2.<java.lang.StringBuilder: java.lang.StringBuilder append(java.lang.String)>("Unsupported type ");
+
+        $r4 = virtualinvoke r0.<java.lang.Object: java.lang.Class getClass()>();
+
+        $r5 = virtualinvoke $r4.<java.lang.Class: java.lang.String getName()>();
+
+        $r6 = virtualinvoke $r3.<java.lang.StringBuilder: java.lang.StringBuilder append(java.lang.String)>($r5);
+
+        $r7 = virtualinvoke $r6.<java.lang.StringBuilder: java.lang.String toString()>();
+
+        specialinvoke $r1.<java.lang.IllegalArgumentException: void <init>(java.lang.String)>($r7);
+
+        throw $r1;
+    }
+
+    public volatile java.io.Serializable transform(java.lang.Object)
+    {
+        ch.qos.logback.access.net.AccessEventPreSerializationTransformer r0;
+        java.lang.Object r1;
+        ch.qos.logback.access.spi.IAccessEvent $r2;
+        java.io.Serializable $r3;
+
+        r0 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+
+        r1 := @parameter0: java.lang.Object;
+
+        $r2 = (ch.qos.logback.access.spi.IAccessEvent) r1;
+
+        $r3 = virtualinvoke r0.<ch.qos.logback.access.net.AccessEventPreSerializationTransformer: java.io.Serializable transform(ch.qos.logback.access.spi.IAccessEvent)>($r2);
+
+        return $r3;
+    }
+}

--- a/mvnc-vs-obfs/example2/obfs/AccessEventPreSerializationTransformer.jnorm2.jimple
+++ b/mvnc-vs-obfs/example2/obfs/AccessEventPreSerializationTransformer.jnorm2.jimple
@@ -1,0 +1,31 @@
+public class ch.qos.logback.access.net.AccessEventPreSerializationTransformer extends java.lang.Object implements ch.qos.logback.core.spi.PreSerializationTransformer
+{
+public void <init>()
+{
+ch.qos.logback.access.net.AccessEventPreSerializationTransformer v0;
+v0 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+specialinvoke v0.<java.lang.Object: void <init>()>();
+return;
+}
+public java.io.Serializable transform(ch.qos.logback.access.spi.IAccessEvent)
+{
+ch.qos.logback.access.net.AccessEventPreSerializationTransformer v0;
+java.lang.Class v4;
+java.lang.String v5, v6;
+java.lang.IllegalArgumentException v3;
+ch.qos.logback.access.spi.IAccessEvent v1;
+boolean v2;
+v0 := @this: ch.qos.logback.access.net.AccessEventPreSerializationTransformer;
+v1 := @parameter0: ch.qos.logback.access.spi.IAccessEvent;
+v2 = v1 instanceof ch.qos.logback.access.spi.AccessEvent;
+if v2 == 0 goto label1;
+return v1;
+label1:
+v3 = new java.lang.IllegalArgumentException;
+v4 = virtualinvoke v1.<java.lang.Object: java.lang.Class getClass()>();
+v5 = virtualinvoke v4.<java.lang.Class: java.lang.String getName()>();
+v6 = dynamicinvoke "makeConcatWithConstants" <java.lang.String (java.lang.String)>(v5) <java.lang.invoke.StringConcatFactory: java.lang.invoke.CallSite makeConcatWithConstants(java.lang.invoke.MethodHandles$Lookup,java.lang.String,java.lang.invoke.MethodType,java.lang.String,java.lang.Object[])>("Unsupported type \u0001");
+specialinvoke v3.<java.lang.IllegalArgumentException: void <init>(java.lang.String)>(v6);
+throw v3;
+}
+}


### PR DESCRIPTION
Also mention the order of arguments to `diff` (which differs between examples, since it's based on lexicographical ordering...).