### PR TITLE
Superclass difference

### DIFF
--- a/mvnc-vs-gaoss/example7/README.md
+++ b/mvnc-vs-gaoss/example7/README.md
@@ -48,6 +48,8 @@ unzip -lv groovy-2.5.23.jar|grep -Ff groovy-2.5.23.jar.filelist.dupes.unequal > 
 `mvnc/org.codehaus.groovy.antlr.GroovySourceToken.javap` was produced using `javap -cp mvnc/groovy-2.5.23.jar org.codehaus.groovy.antlr.GroovySourceToken > mvnc/org.codehaus.groovy.antlr.GroovySourceToken.javap`, and similarly for `gaoss/org.codehaus.groovy.antlr.GroovySourceToken.javap`.
 As their diff `org.codehaus.groovy.antlr.GroovySourceToken.javap.diff` shows, the mvnc version names the shaded class `groovyjarjarantlr.Token` as its superclass, while gaoss names the original class `antlr.Token` as its superclass.
 
+The build metadata specifying the shading can be found [here](https://github.com/groovy/groovy-eclipse/blob/master/base/org.codehaus.groovy30/build.antlr4x#L30).
+
 ## Obtaining Google AOSS files
 
 After first [setting up Google Assured Open Source Software access](https://cloud.google.com/assured-open-source-software/docs/enable) for a [Google Cloud Platform](https://cloud.google.com/) account, and ensuring a valid service account access token is in the file `service-account-access-token`, GAOSS files can be downloaded using the following command, replacing `$P` with the path in question:

--- a/mvnc-vs-gaoss/example7/README.md
+++ b/mvnc-vs-gaoss/example7/README.md
@@ -20,7 +20,7 @@ These file lists were sorted and duplicates were removed using `sort -u < groovy
 All of these files are in top-level directories that appear to result from removing periods from package names.
 One additional file, `META-INF/INDEX.LIST`, is also missing from the gaoss jar.
 
-## Duplicate files in tha Google AOSS jar
+## Duplicate files in the Google AOSS jar
 
 Surprisingly, in addition to the files missing in gaoss, gaoss contains **two copies** of 409 files.
 (It is not clear that this is a valid use of the zip format.)
@@ -42,6 +42,11 @@ sort < groovy-2.5.23.jar.filelist.withcrcs | uniq | cut -c11- | sort | uniq -d >
 # Get the metadata (size, CRC, etc.) for all appearances of these filenames in the zip
 unzip -lv groovy-2.5.23.jar|grep -Ff groovy-2.5.23.jar.filelist.dupes.unequal > groovy-2.5.23.jar.filelist.dupes.unequal.detail
 ```
+
+## Superclass difference
+
+`mvnc/org.codehaus.groovy.antlr.GroovySourceToken.javap` was produced using `javap -cp mvnc/groovy-2.5.23.jar org.codehaus.groovy.antlr.GroovySourceToken > mvnc/org.codehaus.groovy.antlr.GroovySourceToken.javap`, and similarly for `gaoss/org.codehaus.groovy.antlr.GroovySourceToken.javap`.
+As their diff `org.codehaus.groovy.antlr.GroovySourceToken.javap.diff` shows, the mvnc version names the shaded class `groovyjarjarantlr.Token` as its superclass, while gaoss names the original class `antlr.Token` as its superclass.
 
 ## Obtaining Google AOSS files
 

--- a/mvnc-vs-gaoss/example7/gaoss/org.codehaus.groovy.antlr.GroovySourceToken.javap
+++ b/mvnc-vs-gaoss/example7/gaoss/org.codehaus.groovy.antlr.GroovySourceToken.javap
@@ -1,0 +1,20 @@
+Compiled from "GroovySourceToken.java"
+public class org.codehaus.groovy.antlr.GroovySourceToken extends antlr.Token implements org.codehaus.groovy.antlr.SourceInfo {
+  protected int line;
+  protected java.lang.String text;
+  protected int col;
+  protected int lineLast;
+  protected int colLast;
+  public org.codehaus.groovy.antlr.GroovySourceToken(int);
+  public int getLine();
+  public java.lang.String getText();
+  public void setLine(int);
+  public void setText(java.lang.String);
+  public java.lang.String toString();
+  public int getColumn();
+  public void setColumn(int);
+  public int getLineLast();
+  public void setLineLast(int);
+  public int getColumnLast();
+  public void setColumnLast(int);
+}

--- a/mvnc-vs-gaoss/example7/mvnc/org.codehaus.groovy.antlr.GroovySourceToken.javap
+++ b/mvnc-vs-gaoss/example7/mvnc/org.codehaus.groovy.antlr.GroovySourceToken.javap
@@ -1,0 +1,20 @@
+Compiled from "GroovySourceToken.java"
+public class org.codehaus.groovy.antlr.GroovySourceToken extends groovyjarjarantlr.Token implements org.codehaus.groovy.antlr.SourceInfo {
+  protected int line;
+  protected java.lang.String text;
+  protected int col;
+  protected int lineLast;
+  protected int colLast;
+  public org.codehaus.groovy.antlr.GroovySourceToken(int);
+  public int getLine();
+  public java.lang.String getText();
+  public void setLine(int);
+  public void setText(java.lang.String);
+  public java.lang.String toString();
+  public int getColumn();
+  public void setColumn(int);
+  public int getLineLast();
+  public void setLineLast(int);
+  public int getColumnLast();
+  public void setColumnLast(int);
+}

--- a/mvnc-vs-gaoss/example7/org.codehaus.groovy.antlr.GroovySourceToken.javap.diff
+++ b/mvnc-vs-gaoss/example7/org.codehaus.groovy.antlr.GroovySourceToken.javap.diff
@@ -1,0 +1,4 @@
+2c2
+< public class org.codehaus.groovy.antlr.GroovySourceToken extends antlr.Token implements org.codehaus.groovy.antlr.SourceInfo {
+---
+> public class org.codehaus.groovy.antlr.GroovySourceToken extends groovyjarjarantlr.Token implements org.codehaus.groovy.antlr.SourceInfo {


### PR DESCRIPTION
Add a section demonstrating the difference in superclass for `org.codehaus.groovy.antlr.GroovySourceToken` in `org.codehaus.groovy:groovy:2.5.23` between mvnc and gaoss.